### PR TITLE
Add custom Xiaomi struct parsing

### DIFF
--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -616,7 +616,10 @@ ru.clause('strPreLenUint8', function (name) {
 	parsedBufLen += 1;
 	this.uint8('len').tap(function () {
 		var attrId = this.vars['attrId'];
-		if (attrId===65281){
+
+		// Added custom xiaoMiStruct parser, should be removed once following PR is accepted
+		// https://github.com/zigbeer/zcl-packet/pull/10
+		if (attrId === 65281){
 			ru['xiaoMiStruct'](name)(this);
 			delete this.vars.len;
 		}else{

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -613,12 +613,36 @@ ru.clause('uint64', function (name) {
 });
 
 ru.clause('strPreLenUint8', function (name) {
-    parsedBufLen += 1;
-    this.uint8('len').tap(function () {
-        parsedBufLen += this.vars.len;
-        this.string(name, this.vars.len);
-        delete this.vars.len;
-    });
+	parsedBufLen += 1;
+	this.uint8('len').tap(function () {
+		var attrId = this.vars['attrId'];
+		if (attrId===65281){
+			ru['xiaoMiStruct'](name)(this);
+			delete this.vars.len;
+		}else{
+			parsedBufLen += this.vars.len;
+			this.string(name, this.vars.len);
+			delete this.vars.len;
+		}
+	});
+});
+
+ru.clause('xiaoMiStruct', function (name) {
+	var stopLen = parsedBufLen+this.vars.len-2;
+	this.tap(function(){
+		this.loop('attrData', function (end) {
+			parsedBufLen += 2;
+			this.uint8('index').uint8('dT').tap(function () {
+				ru.variable('data', 'dT')(this);
+			});
+			if (stopLen <= parsedBufLen ) end();
+		}).tap(function () {
+			this.vars.attrData.forEach(function (element) {
+				delete element.__proto__;
+				delete element.dT;
+			});
+		});
+	});
 });
 
 ru.clause('strPreLenUint16', function (name) {


### PR DESCRIPTION
This PR is based on this issue (https://github.com/zigbeer/zigbee-shepherd/issues/26#issuecomment-350200347) and as requested by @WeeJeWel and TedTolboom. It adds support for the parsing of raw lifeline reports send by Xiaomi devices, basically it detects if attribute id 65281 is present in a report and will then use different parsing logic. It does affect other attributes or reports.